### PR TITLE
fix for "! LaTeX Error: Environment cslreferences undefined."

### DIFF
--- a/src/mla8_pandoc_template.latex
+++ b/src/mla8_pandoc_template.latex
@@ -1,5 +1,9 @@
 \documentclass[letterpaper, 12pt]{scrartcl}
 
+\newenvironment{cslreferences}%
+  {}%
+  {\par}
+
 \usepackage{lmodern}
 
 % Use double spacing


### PR DESCRIPTION
pandoc started requiring a new "environment" to exist, apparently breaking every template everywhere.  Here's a change based on https://stackoverflow.com/posts/59196065/revisions .  I don't know anything about the LaTeX language so I hope that's useful but please treat with scrutiny.  It got me going.  Thanks for sharing your MLA template.  Much nicer not doing this manually in a word processor.